### PR TITLE
Nginx.conf - Updated Max Upload to Frontend

### DIFF
--- a/lib/nginx.conf
+++ b/lib/nginx.conf
@@ -39,6 +39,10 @@ http {
         # fetch OCSP records from URL in ssl_certificate and cache them
         ssl_stapling on;
         ssl_stapling_verify on;
+        
+        # Set upload to sensible value as defaults to 1M if not present 
+        client_max_body_size 10M;
+
 
         location / {
           proxy_pass http://site/;


### PR DESCRIPTION
To fix CollectionFS upload issues updated the nginx.conf to reflect bigger upload sizes as nginx defaults to 1 megabyte maximum uploads causing errors from the frontend. Fixes #5. 
