### PR TITLE
Fix for "upstream sent too big header" issues #7

### DIFF
--- a/lib/nginx.conf
+++ b/lib/nginx.conf
@@ -43,7 +43,9 @@ http {
         
         # Set upload to sensible value as defaults to 1M if not present 
         client_max_body_size 10M;
-
+        
+        # Fix for "upstream sent too big header" issues #7 - it may need a bigger size for some apps
+        proxy_buffer_size 8k;
 
         location / {
           proxy_pass http://site/;


### PR DESCRIPTION
In some cases a bigger buffer size would be needed.
