### PR TITLE
security fix OpenSSL Oracle vuln. (CVE-2016-2107)

### DIFF
--- a/lib/install-nginx.sh
+++ b/lib/install-nginx.sh
@@ -1,4 +1,4 @@
-set -e 
+set -e
 
 BUILD_DIR=/tmp/nginx
 NGINX_VERSION=1.8.0
@@ -11,6 +11,7 @@ useradd $NGINX_USER || :
 # install dependencies
 apt-get update
 apt-get -y install libpcre3-dev libssl-dev openssl build-essential wget
+apt-get -y --only-upgrade install libssl1.0.0 openssl
 
 # start building process
 


### PR DESCRIPTION
Add security fix for OpenSSL Padding Oracle vuln. (CVE-2016-2107)

Relates to SSL insecurity reporting here:
https://github.com/meteorhacks/mup-frontend-server/issues/14

Fix found at:
https://github.com/ckiely91/mup-frontend-server/commit/e151dd6939a0f0587e01dfda0c260ce0409f6883
